### PR TITLE
Ux improvements

### DIFF
--- a/src/background/agent/Agent.ts
+++ b/src/background/agent/Agent.ts
@@ -1,5 +1,6 @@
 import {
   DynamicCache,
+  InterruptableStoppingCriteria,
   TextGenerationPipeline,
   TextStreamer,
   pipeline,
@@ -10,6 +11,9 @@ import {
   AgentMetrics,
   ChatMessage,
   ChatMessageAssistant,
+  ToolPermissionDecision,
+  ToolPermissions,
+  ToolStatus,
 } from "../../shared/types.ts";
 import { extractToolCalls } from "./extractToolCalls.ts";
 import { ToolCallPayload } from "./types.ts";
@@ -29,20 +33,63 @@ type GenerationMetrics = AgentMetrics;
 export type AgentRunMetrics = AgentMetrics;
 
 let pipe: TextGenerationPipeline | null = null;
-const SYSTEM_PROMPT =
-  "You are a helpful assistant with access to external tools declared in this conversation. " +
-  "Never claim you do not have tools when tool declarations are present. " +
-  "When asked what tools you have, list the declared tool names exactly. " +
-  "If you decide to use a tool, briefly explain what you are doing before calling it.";
+const SYSTEM_PROMPT_BASE =
+  "You are a helpful assistant running inside a browser extension. " +
+  "You can interact with the user's browser via the tools declared in this conversation — never claim you have no tools when declarations are present. " +
+  "When the user says 'this page', 'the page', 'this site', 'this tab', 'this article', or anything similar without giving a URL, they mean their currently active tab. " +
+  "Do not ask the user for a URL in that case. Call the ask_website tool to read content from the active tab. " +
+  "Each tool call requires the user's approval — they will be prompted, so call tools confidently when they help fulfil the request. " +
+  "If you decide to use a tool, briefly say what you are about to do before calling it.";
+
+const buildSystemPrompt = (activeTab?: {
+  title?: string;
+  url?: string;
+}): string => {
+  if (!activeTab?.url) return SYSTEM_PROMPT_BASE;
+  const title = activeTab.title || "(untitled)";
+  return (
+    SYSTEM_PROMPT_BASE +
+    `\n\nThe user's currently active browser tab:\n- Title: ${title}\n- URL: ${activeTab.url}`
+  );
+};
+
+const getActiveTabInfo = async (): Promise<
+  { title?: string; url?: string } | undefined
+> => {
+  try {
+    const [tab] = await chrome.tabs.query({
+      active: true,
+      lastFocusedWindow: true,
+    });
+    if (!tab?.url?.startsWith("http")) return undefined;
+    return { title: tab.title, url: tab.url };
+  } catch {
+    return undefined;
+  }
+};
+
 const createInitialMessages = (): Array<Message> => [
   {
     role: "system",
-    content: SYSTEM_PROMPT,
+    content: SYSTEM_PROMPT_BASE,
   },
 ];
 const END_OF_TEXT_TOKEN_REGEX = /<\|end_of_text\|>/g;
 const sanitizeModelText = (text: string) =>
   text.replace(END_OF_TEXT_TOKEN_REGEX, "").trim();
+
+const PERMISSIONS_STORAGE_KEY = "toolPermissions";
+
+const loadToolPermissions = async (): Promise<ToolPermissions> => {
+  const result = await chrome.storage.local.get(PERMISSIONS_STORAGE_KEY);
+  return (result[PERMISSIONS_STORAGE_KEY] as ToolPermissions) || {};
+};
+
+const saveToolPermissionAlways = async (toolName: string) => {
+  const permissions = await loadToolPermissions();
+  permissions[toolName] = "always_allow";
+  await chrome.storage.local.set({ [PERMISSIONS_STORAGE_KEY]: permissions });
+};
 
 const getTextGenerationPipeline = async (
   onDownloadProgress: (id: string, percentage: number) => void = () => {}
@@ -76,8 +123,36 @@ class Agent {
     (chatMessages: Array<ChatMessage>) => void
   > = [];
   private tools: Array<WebMCPTool> = [];
+  private stoppingCriteria = new InterruptableStoppingCriteria();
+  private pendingPermissions = new Map<
+    string,
+    (decision: ToolPermissionDecision) => void
+  >();
 
   constructor() {}
+
+  public cancel = () => {
+    this.stoppingCriteria.interrupt();
+    for (const resolve of this.pendingPermissions.values()) resolve("deny");
+    this.pendingPermissions.clear();
+  };
+
+  public resolvePermission = (
+    toolCallId: string,
+    decision: ToolPermissionDecision
+  ) => {
+    const resolve = this.pendingPermissions.get(toolCallId);
+    if (!resolve) return;
+    this.pendingPermissions.delete(toolCallId);
+    resolve(decision);
+  };
+
+  private requestPermission = (
+    toolCallId: string
+  ): Promise<ToolPermissionDecision> =>
+    new Promise((resolve) => {
+      this.pendingPermissions.set(toolCallId, resolve);
+    });
 
   get chatMessages() {
     return this._chatMessages;
@@ -153,6 +228,7 @@ class Agent {
       max_new_tokens: 1024,
       do_sample: false,
       streamer,
+      stopping_criteria: this.stoppingCriteria,
     });
 
     const promptLength = Number(input.input_ids.dims.at(-1) ?? 0);
@@ -233,6 +309,25 @@ class Agent {
   };
 
   public runAgent = async (prompt: string): Promise<AgentRunMetrics> => {
+    this.stoppingCriteria.reset();
+    const activeTab = await getActiveTabInfo();
+    const systemContent = buildSystemPrompt(activeTab);
+    const systemIdx = this.messages.findIndex((m) => m.role === "system");
+    const previousSystemContent =
+      systemIdx >= 0 ? this.messages[systemIdx].content : null;
+    if (systemIdx >= 0) {
+      this.messages[systemIdx] = {
+        ...this.messages[systemIdx],
+        content: systemContent,
+      };
+    } else {
+      this.messages = [{ role: "system", content: systemContent }, ...this.messages];
+    }
+    if (previousSystemContent !== systemContent) {
+      // System prompt changed — KV cache prefix is no longer valid.
+      void this.pastKeyValues?.dispose();
+      this.pastKeyValues = null;
+    }
     let roleForGeneration: "user" | "tool" = "user";
     let appendPromptMessage = true;
     const start = performance.now();
@@ -246,6 +341,7 @@ class Agent {
       { role: "user", content: prompt },
     ];
     const prevChatMessages = this.chatMessages;
+
     const assistantMessage: ChatMessageAssistant = {
       role: "assistant",
       content: "",
@@ -264,6 +360,7 @@ class Agent {
 
     this.chatMessages = [...prevChatMessages, assistantMessage];
 
+    try {
     let messageInThisAgentRun = "";
     const updateAssistantMessage = (response: string) => {
       const { toolCalls, message } = extractToolCalls(response);
@@ -279,6 +376,7 @@ class Agent {
               )})`,
               id: tool.id,
               result: "",
+              status: "pending_permission",
             },
           ];
         }
@@ -318,11 +416,17 @@ class Agent {
       const { toolCalls, message } = extractToolCalls(finalResponse);
       messageInThisAgentRun = message;
 
-      if (toolCalls.length === 0) {
+      if (this.stoppingCriteria.interrupted || toolCalls.length === 0) {
         prompt = null;
       } else {
+        const updateToolStatus = (id: string, status: ToolStatus) => {
+          assistantMessage.tools = assistantMessage.tools.map((tool) =>
+            tool.id === id ? { ...tool, status } : tool
+          );
+          this.chatMessages = [...prevChatMessages, assistantMessage];
+        };
         const toolResponses = await Promise.all(
-          toolCalls.map(this.executeToolCall)
+          toolCalls.map((call) => this.executeToolCall(call, updateToolStatus))
         );
 
         for (let i = this.messages.length - 1; i >= 0; i -= 1) {
@@ -362,12 +466,12 @@ class Agent {
           })),
         ];
 
-        assistantMessage.tools = assistantMessage.tools.map((tool) => ({
-          ...tool,
-          result:
-            toolResponses.find(({ id }) => id === tool.id)?.result ||
-            tool.result,
-        }));
+        assistantMessage.tools = assistantMessage.tools.map((tool) => {
+          const response = toolResponses.find(({ id }) => id === tool.id);
+          return response
+            ? { ...tool, result: response.result || tool.result }
+            : tool;
+        });
 
         this.chatMessages = [...prevChatMessages, assistantMessage];
         prompt =
@@ -401,19 +505,52 @@ class Agent {
       tokensPerSecond: decodeMs > 0 ? generatedTokens / (decodeMs / 1000) : 0,
       msPerToken: generatedTokens > 0 ? decodeMs / generatedTokens : 0,
     };
+    } finally {
+      if (this.stoppingCriteria.interrupted) {
+        // KV cache was mid-write when interrupted; reusing it corrupts the next run.
+        void this.pastKeyValues?.dispose();
+        this.pastKeyValues = null;
+      }
+    }
   };
 
   private executeToolCall = async (
-    toolCall: ToolCallPayload
+    toolCall: ToolCallPayload,
+    updateStatus: (id: string, status: ToolStatus) => void
   ): Promise<{ id: string; name: string; result: string }> => {
     const toolToUse = this.tools.find((t) => t.name === toolCall.name);
     if (!toolToUse)
       throw new Error(`Tool '${toolCall.name}' not found or is disabled.`);
 
+    const permissions = await loadToolPermissions();
+    let decision: ToolPermissionDecision;
+    if (permissions[toolCall.name] === "always_allow") {
+      decision = "allow_once";
+    } else {
+      updateStatus(toolCall.id, "pending_permission");
+      decision = await this.requestPermission(toolCall.id);
+      if (decision === "always_allow") {
+        await saveToolPermissionAlways(toolCall.name);
+      }
+    }
+
+    if (decision === "deny") {
+      updateStatus(toolCall.id, "denied");
+      return {
+        id: toolCall.id,
+        name: toolCall.name,
+        result:
+          "The user denied permission to run this tool. Do not retry it; if needed, ask the user how to proceed without it.",
+      };
+    }
+
+    updateStatus(toolCall.id, "running");
+    const result = await executeWebMCPTool(toolToUse, toolCall.arguments);
+    updateStatus(toolCall.id, "completed");
     return {
       id: toolCall.id,
       name: toolCall.name,
-      result: await executeWebMCPTool(toolToUse, toolCall.arguments),
+      result,
     };
   };
 

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -185,6 +185,20 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
     return true;
   }
 
+  if (message.type === BackgroundTasks.AGENT_CANCEL) {
+    const agent = getAgent();
+    agent.cancel();
+    sendResponse({ status: ResponseStatus.SUCCESS });
+    return true;
+  }
+
+  if (message.type === BackgroundTasks.TOOL_PERMISSION_RESPOND) {
+    const agent = getAgent();
+    agent.resolvePermission(message.toolCallId, message.decision);
+    sendResponse({ status: ResponseStatus.SUCCESS });
+    return true;
+  }
+
   if (message.type === BackgroundTasks.EXTRACT_FEATURES) {
     featureExtractor
       .extractFeatures([message.text])

--- a/src/background/tools/askWebsite.ts
+++ b/src/background/tools/askWebsite.ts
@@ -2,6 +2,24 @@ import { ContentTasks, WebsitePart } from "../../shared/types.ts";
 import { WebMCPTool } from "../agent/webMcp.tsx";
 import FeatureExtractor from "../utils/FeatureExtractor.ts";
 
+const sendMessageWithInjection = async (
+  tabId: number,
+  message: unknown
+): Promise<any> => {
+  try {
+    return await chrome.tabs.sendMessage(tabId, message);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (!msg.includes("Receiving end does not exist")) throw error;
+    // Content script wasn't auto-injected (page predates the extension reload).
+    await chrome.scripting.executeScript({
+      target: { tabId },
+      files: ["content.js"],
+    });
+    return await chrome.tabs.sendMessage(tabId, message);
+  }
+};
+
 class WebsiteContentManager {
   private currentPageParts: WebsitePart[] = [];
   private featureExtractor: FeatureExtractor;
@@ -93,7 +111,7 @@ class WebsiteContentManager {
 
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const response = await chrome.tabs.sendMessage(tabId, {
+    const response = await sendMessageWithInjection(tabId, {
       type: ContentTasks.EXTRACT_PAGE_DATA,
     });
 
@@ -269,7 +287,7 @@ export const highlightWebsiteElementTool: WebMCPTool = {
         return "Error: No active tab found";
       }
 
-      await chrome.tabs.sendMessage(tab.id, {
+      await sendMessageWithInjection(tab.id, {
         type: ContentTasks.HIGHLIGHT_ELEMENTS,
         payload: {
           id,

--- a/src/shared/tools.ts
+++ b/src/shared/tools.ts
@@ -10,3 +10,40 @@ export const AvailableTools = {
 } as const;
 
 export type ToolName = (typeof AvailableTools)[keyof typeof AvailableTools];
+
+export const toolMetadata: Record<
+  ToolName,
+  { label: string; description: string }
+> = {
+  [AvailableTools.GET_OPEN_TABS]: {
+    label: "Get Open Tabs",
+    description: "List all currently open browser tabs",
+  },
+  [AvailableTools.GO_TO_TAB]: {
+    label: "Go to Tab",
+    description: "Navigate to a specific tab",
+  },
+  [AvailableTools.OPEN_URL]: {
+    label: "Open URL",
+    description: "Open a new URL in a tab",
+  },
+  [AvailableTools.CLOSE_TAB]: {
+    label: "Close Tab",
+    description: "Close a specific tab",
+  },
+  [AvailableTools.FIND_HISTORY]: {
+    label: "Find History",
+    description: "Search browsing history with semantic search",
+  },
+  [AvailableTools.ASK_WEBSITE]: {
+    label: "Ask Website",
+    description: "Extract and analyze website content",
+  },
+  [AvailableTools.HIGHLIGHT_WEBSITE_ELEMENT]: {
+    label: "Highlight Website Element",
+    description: "Highlight elements on a webpage",
+  },
+};
+
+export const getToolLabel = (name: string): string =>
+  toolMetadata[name as ToolName]?.label ?? name;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,6 +12,8 @@ export enum BackgroundTasks {
   AGENT_GENERATE_TEXT,
   AGENT_GET_MESSAGES,
   AGENT_CLEAR,
+  AGENT_CANCEL,
+  TOOL_PERMISSION_RESPOND,
 }
 
 export enum BackgroundMessages {
@@ -33,11 +35,24 @@ export interface ChatMessageUser {
   content: string;
 }
 
+export type ToolStatus =
+  | "pending_permission"
+  | "running"
+  | "completed"
+  | "denied";
+
+export type ToolPermissionDecision = "allow_once" | "always_allow" | "deny";
+
+export type ToolPermissionGrant = "always_allow";
+
+export type ToolPermissions = Partial<Record<string, ToolPermissionGrant>>;
+
 export interface ChatMessageTool {
   name: string;
   functionSignature: string;
   id: string;
   result: string;
+  status: ToolStatus;
 }
 
 export interface AgentMetrics {

--- a/src/sidebar/chat/Chat.tsx
+++ b/src/sidebar/chat/Chat.tsx
@@ -17,6 +17,7 @@ import {
 import cn from "../utils/classnames.ts";
 import ChatCommands, { ChatCommandsRef, Command } from "./ChatCommands.tsx";
 import ChatToolsModal from "./ChatToolsModal.tsx";
+import CopyButton from "./CopyButton.tsx";
 import MessageContent from "./MessageContent.tsx";
 
 const MAX_INPUT_HEIGHT_PX = 200;
@@ -195,30 +196,40 @@ export default function Chat() {
             </p>
           </div>
         ) : (
-          messages.map((message, index) => (
-            <div
-              key={index}
-              className={cn(
-                "max-w-[85%] rounded-md px-4 py-3",
-                message.role === "user"
-                  ? "ml-auto bg-chrome-accent-primary text-chrome-bg-primary"
-                  : "bg-chrome-bg-secondary"
-              )}
-            >
-              <div className="text-sm">
-                {message.role === "user" ? (
-                  message.content
-                ) : (
-                  <MessageContent
-                    content={message.content}
-                    tools={message.tools}
-                    metrics={message.metrics}
-                    onPermissionDecision={onPermissionDecision}
-                  />
-                )}
+          messages.map((message, index) => {
+            const anchor = `--msg-${index}`;
+            return (
+              <div key={index} className="message-row relative">
+                <div
+                  className={cn(
+                    "message-bubble max-w-[85%] px-4 py-3",
+                    message.role === "user"
+                      ? "user-message ml-auto bg-chrome-accent-primary text-chrome-bg-primary"
+                      : "bg-chrome-bg-secondary"
+                  )}
+                  style={{ anchorName: anchor } as React.CSSProperties}
+                >
+                  <div className="text-sm">
+                    {message.role === "user" ? (
+                      message.content
+                    ) : (
+                      <MessageContent
+                        content={message.content}
+                        tools={message.tools}
+                        metrics={message.metrics}
+                        onPermissionDecision={onPermissionDecision}
+                      />
+                    )}
+                  </div>
+                </div>
+                <CopyButton
+                  text={message.content}
+                  align={message.role === "user" ? "left" : "right"}
+                  anchor={anchor}
+                />
               </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
 

--- a/src/sidebar/chat/Chat.tsx
+++ b/src/sidebar/chat/Chat.tsx
@@ -1,19 +1,25 @@
-import { Hammer } from "lucide-react";
-import { KeyboardEvent, useEffect, useRef, useState } from "react";
+import {
+  KeyboardEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { Controller, useForm } from "react-hook-form";
 
-import { ToolName } from "../../shared/tools.ts";
 import {
   BackgroundMessages,
   BackgroundTasks,
   ChatMessage,
   ResponseStatus,
+  ToolPermissionDecision,
 } from "../../shared/types.ts";
-import { Button, InputText } from "../theme";
 import cn from "../utils/classnames.ts";
 import ChatCommands, { ChatCommandsRef, Command } from "./ChatCommands.tsx";
 import ChatToolsModal from "./ChatToolsModal.tsx";
 import MessageContent from "./MessageContent.tsx";
+
+const MAX_INPUT_HEIGHT_PX = 200;
 
 interface FormParams {
   input: string;
@@ -21,44 +27,24 @@ interface FormParams {
 
 export default function Chat() {
   const messagesContainerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
   const commandsRef = useRef<ChatCommandsRef>(null);
-  const {
-    control,
-    formState: { errors },
-    handleSubmit,
-    reset,
-    setValue,
-    watch,
-  } = useForm<FormParams>({
-    defaultValues: {
-      input: "",
-    },
-  });
+  const { control, handleSubmit, reset, setValue, watch } = useForm<FormParams>(
+    {
+      defaultValues: {
+        input: "",
+      },
+    }
+  );
   const [messages, setMessages] = useState<Array<ChatMessage>>([]);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [showCommands, setShowCommands] = useState<boolean>(false);
   const [toolsOpen, setToolsOpen] = useState<boolean>(false);
 
-  const [activeTools, setActiveTools] = useState<ToolName[]>();
-  const [toolsLoaded, setToolsLoaded] = useState<boolean>(false);
-
   const inputValue = watch("input");
 
-  useEffect(() => {
-    chrome.storage.local.get(["activeTools"], (result) => {
-      if (result.activeTools && Array.isArray(result.activeTools)) {
-        setActiveTools(result.activeTools as ToolName[]);
-      }
-      setToolsLoaded(true);
-    });
-  }, []);
-
-  useEffect(() => {
-    if (toolsLoaded) {
-      chrome.storage.local.set({ activeTools });
-    }
-  }, [activeTools, toolsLoaded]);
+  const stickToBottomRef = useRef(true);
+  const isPointerDownRef = useRef(false);
 
   const scrollToBottom = () => {
     if (messagesContainerRef.current) {
@@ -67,7 +53,32 @@ export default function Chat() {
     }
   };
 
+  const handleScroll = () => {
+    const el = messagesContainerRef.current;
+    if (!el) return;
+    const distanceFromBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
+    stickToBottomRef.current = distanceFromBottom < 40;
+  };
+
   useEffect(() => {
+    const onDown = () => {
+      isPointerDownRef.current = true;
+    };
+    const onUp = () => {
+      isPointerDownRef.current = false;
+    };
+    window.addEventListener("mousedown", onDown);
+    window.addEventListener("mouseup", onUp);
+    return () => {
+      window.removeEventListener("mousedown", onDown);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!stickToBottomRef.current) return;
+    if (isPointerDownRef.current) return;
+    if (window.getSelection()?.toString()) return;
     scrollToBottom();
   }, [messages]);
 
@@ -115,13 +126,26 @@ export default function Chat() {
     });
   }, []);
 
-  // Forward keyboard events to ChatCommands
-  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+  useEffect(() => {
+    const el = inputRef.current;
+    if (!el) return;
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, MAX_INPUT_HEIGHT_PX)}px`;
+  }, [inputValue]);
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
     commandsRef.current?.handleKeyDown(e);
+    if (e.defaultPrevented) return;
+    if (e.key === "Enter" && !e.shiftKey && !showCommands) {
+      e.preventDefault();
+      handleSubmit(onSubmit)();
+    }
   };
 
   const onSubmit = (data: FormParams) => {
+    if (isLoading) return;
     setIsLoading(true);
+    stickToBottomRef.current = true;
     reset();
 
     inputRef.current?.focus();
@@ -140,10 +164,28 @@ export default function Chat() {
     );
   };
 
+  const onCancel = () => {
+    chrome.runtime.sendMessage({
+      type: BackgroundTasks.AGENT_CANCEL,
+    });
+  };
+
+  const onPermissionDecision = useCallback(
+    (toolCallId: string, decision: ToolPermissionDecision) => {
+      chrome.runtime.sendMessage({
+        type: BackgroundTasks.TOOL_PERMISSION_RESPOND,
+        toolCallId,
+        decision,
+      });
+    },
+    []
+  );
+
   return (
     <div className="flex flex-col h-full">
       <div
         ref={messagesContainerRef}
+        onScroll={handleScroll}
         className="flex-1 overflow-y-auto px-6 py-4 space-y-4"
       >
         {(messages || []).length === 0 ? (
@@ -171,6 +213,7 @@ export default function Chat() {
                     content={message.content}
                     tools={message.tools}
                     metrics={message.metrics}
+                    onPermissionDecision={onPermissionDecision}
                   />
                 )}
               </div>
@@ -179,7 +222,7 @@ export default function Chat() {
         )}
       </div>
 
-      <div className="border-t border-chrome-border px-6 py-4 bg-chrome-bg-secondary relative">
+      <div className="select-none border-t border-chrome-border px-4 py-3 bg-chrome-bg-secondary relative">
         <ChatCommands
           ref={commandsRef}
           commands={commands}
@@ -188,54 +231,74 @@ export default function Chat() {
           onClose={() => setShowCommands(false)}
           onExecute={() => setShowCommands(false)}
         />
-        {toolsOpen && (
-          <ChatToolsModal
-            activeTools={activeTools}
-            onClose={() => setToolsOpen(false)}
-            onSubmit={(tools: ToolName[]) => {
-              setActiveTools(tools);
-              setToolsOpen(false);
-            }}
-          />
-        )}
-        <form onSubmit={handleSubmit(onSubmit)} className="flex gap-3">
-          <Button
-            type="button"
-            color="secondary"
-            variant="solid"
-            iconLeft={<Hammer />}
-            onClick={() => setToolsOpen(true)}
-          />
+        {toolsOpen && <ChatToolsModal onClose={() => setToolsOpen(false)} />}
+        <form
+          onSubmit={handleSubmit(onSubmit)}
+          className="rounded-lg border border-chrome-border bg-chrome-bg-primary focus-within:border-chrome-accent-primary transition-colors"
+        >
           <Controller
             name="input"
             control={control}
-            rules={{ required: "Message is required" }}
             render={({ field }) => (
-              <InputText
+              <textarea
                 {...field}
                 id="chat-input"
-                label="Message"
+                rows={1}
                 placeholder="Type your message or / for commands..."
-                //disabled={isLoading}
-                error={errors.input?.message}
-                hideLabel
-                className="flex-1"
                 onKeyDown={handleKeyDown}
                 ref={(e) => {
                   field.ref(e);
-                  (inputRef as any).current = e;
+                  inputRef.current = e;
                 }}
+                className="block w-full resize-none bg-transparent px-3 pt-2.5 pb-1 text-sm text-chrome-text-primary placeholder:text-chrome-text-disabled outline-none overflow-y-auto"
+                style={{ maxHeight: MAX_INPUT_HEIGHT_PX }}
               />
             )}
           />
-          <Button
-            type="submit"
-            disabled={isLoading || showCommands}
-            color="primary"
-            variant="solid"
-          >
-            Send
-          </Button>
+          <div className="flex items-center justify-between px-1.5 pb-1.5">
+            <button
+              type="button"
+              onClick={() => setToolsOpen(true)}
+              className="group cursor-pointer p-1.5"
+              title="Tool permissions"
+            >
+              <span className="block rounded px-2 py-1 text-xs font-medium text-chrome-text-secondary transition-colors group-hover:bg-chrome-hover group-hover:text-chrome-text-primary">
+                Tools
+              </span>
+            </button>
+            {isLoading ? (
+              <button
+                type="button"
+                onClick={onCancel}
+                aria-label="Stop generating"
+                title="Stop"
+                className="group cursor-pointer p-1.5"
+              >
+                <span className="flex h-7 w-7 items-center justify-center rounded text-chrome-text-secondary transition-colors group-hover:bg-chrome-hover group-hover:text-chrome-text-primary">
+                  <span className="block h-2.5 w-2.5 rounded-[2px] bg-current" />
+                </span>
+              </button>
+            ) : (
+              <button
+                type="submit"
+                disabled={showCommands || !inputValue.trim()}
+                aria-label="Send"
+                title="Send (Enter)"
+                className="group cursor-pointer p-1.5 disabled:cursor-not-allowed"
+              >
+                <span
+                  className={cn(
+                    "flex h-7 w-7 items-center justify-center rounded text-base leading-none transition-colors",
+                    inputValue.trim() && !showCommands
+                      ? "text-chrome-accent-primary group-hover:bg-chrome-hover"
+                      : "text-chrome-text-disabled"
+                  )}
+                >
+                  ↵
+                </span>
+              </button>
+            )}
+          </div>
         </form>
       </div>
     </div>

--- a/src/sidebar/chat/ChatCommands.tsx
+++ b/src/sidebar/chat/ChatCommands.tsx
@@ -15,7 +15,7 @@ export interface Command {
 }
 
 export interface ChatCommandsRef {
-  handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => void;
+  handleKeyDown: (e: KeyboardEvent<HTMLElement>) => void;
 }
 
 interface ChatCommandsProps {
@@ -39,7 +39,7 @@ const ChatCommands = forwardRef<ChatCommandsRef, ChatCommandsProps>(
     }, [inputValue]);
 
     useImperativeHandle(ref, () => ({
-      handleKeyDown: (e: KeyboardEvent<HTMLInputElement>) => {
+      handleKeyDown: (e: KeyboardEvent<HTMLElement>) => {
         if (!isOpen || filteredCommands.length === 0) return;
 
         switch (e.key) {

--- a/src/sidebar/chat/ChatToolsModal.tsx
+++ b/src/sidebar/chat/ChatToolsModal.tsx
@@ -1,99 +1,49 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
-import { AvailableTools, ToolName } from "../../shared/tools.ts";
-import { BackgroundTasks, ResponseStatus } from "../../shared/types.ts";
+import {
+  AvailableTools,
+  ToolName,
+  toolMetadata,
+} from "../../shared/tools.ts";
+import { ToolPermissions } from "../../shared/types.ts";
 import { Button, Modal } from "../theme";
 
-interface ChatToolsModalProps {
-  activeTools: ToolName[];
-  onClose: () => void;
-  onSubmit: (tools: ToolName[]) => void;
-}
+const PERMISSIONS_STORAGE_KEY = "toolPermissions";
 
-const toolMetadata: Record<ToolName, { label: string; description: string }> = {
-  [AvailableTools.GET_OPEN_TABS]: {
-    label: "Get Open Tabs",
-    description: "List all currently open browser tabs",
-  },
-  [AvailableTools.GO_TO_TAB]: {
-    label: "Go to Tab",
-    description: "Navigate to a specific tab",
-  },
-  [AvailableTools.OPEN_URL]: {
-    label: "Open URL",
-    description: "Open a new URL in a tab",
-  },
-  [AvailableTools.CLOSE_TAB]: {
-    label: "Close Tab",
-    description: "Close a specific tab",
-  },
-  [AvailableTools.FIND_HISTORY]: {
-    label: "Find History",
-    description: "Search browsing history with semantic search",
-  },
-  [AvailableTools.ASK_WEBSITE]: {
-    label: "Ask Website",
-    description: "Extract and analyze website content",
-  },
-  [AvailableTools.HIGHLIGHT_WEBSITE_ELEMENT]: {
-    label: "Highlight Website Element",
-    description: "Highlight elements on a webpage",
-  },
-};
+export default function ChatToolsModal({ onClose }: { onClose: () => void }) {
+  const [permissions, setPermissions] = useState<ToolPermissions>({});
 
-export default function ChatToolsModal({
-  activeTools,
-  onClose,
-  onSubmit,
-}: ChatToolsModalProps) {
-  const [selectedTools, setSelectedTools] = useState<Set<ToolName>>(
-    new Set(activeTools)
-  );
-  const [isSubmitting, setIsSubmitting] = useState(false);
+  useEffect(() => {
+    chrome.storage.local.get([PERMISSIONS_STORAGE_KEY], (result) => {
+      setPermissions(
+        (result[PERMISSIONS_STORAGE_KEY] as ToolPermissions) || {}
+      );
+    });
+  }, []);
 
-  const handleToggle = (tool: ToolName) => {
-    const newSelected = new Set(selectedTools);
-    if (newSelected.has(tool)) {
-      newSelected.delete(tool);
+  const setAlways = (tool: ToolName, alwaysAllow: boolean) => {
+    const next: ToolPermissions = { ...permissions };
+    if (alwaysAllow) {
+      next[tool] = "always_allow";
     } else {
-      newSelected.add(tool);
+      delete next[tool];
     }
-    setSelectedTools(newSelected);
-  };
-
-  const handleSubmit = () => {
-    setIsSubmitting(true);
-
-    const toolsArray = Array.from(selectedTools);
-
-    // Send AGENT_INITIALIZE with selected tools
-    chrome.runtime.sendMessage(
-      {
-        type: BackgroundTasks.AGENT_INITIALIZE,
-        tools: toolsArray,
-      },
-      (response) => {
-        setIsSubmitting(false);
-        if (response.status === ResponseStatus.SUCCESS) {
-          onSubmit(toolsArray);
-        } else {
-          alert("Failed to initialize agent with selected tools");
-        }
-      }
-    );
+    setPermissions(next);
+    chrome.storage.local.set({ [PERMISSIONS_STORAGE_KEY]: next });
   };
 
   return (
-    <Modal title="Configure Tools" onClose={onClose}>
+    <Modal title="Tool permissions" onClose={onClose}>
       <div className="space-y-4">
         <p className="text-sm text-chrome-text-secondary">
-          Select which tools the agent can use. Changes will reset the current
-          conversation.
+          The agent asks before running a tool. Set "Always allow" to skip the
+          prompt for tools you trust.
         </p>
 
         <div className="space-y-3 overflow-y-auto">
           {Object.values(AvailableTools).map((tool) => {
             const metadata = toolMetadata[tool];
+            const alwaysAllow = permissions[tool] === "always_allow";
             return (
               <div
                 key={tool}
@@ -102,8 +52,8 @@ export default function ChatToolsModal({
                 <input
                   type="checkbox"
                   id={tool}
-                  checked={selectedTools.has(tool)}
-                  onChange={() => handleToggle(tool)}
+                  checked={alwaysAllow}
+                  onChange={(e) => setAlways(tool, e.target.checked)}
                   className="mt-1 h-4 w-4 cursor-pointer rounded border transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none bg-chrome-bg-primary border-chrome-border text-chrome-accent-primary focus:border-chrome-accent-primary focus:ring-chrome-accent-primary focus:ring-offset-chrome-bg-primary"
                 />
                 <label htmlFor={tool} className="flex-1 cursor-pointer">
@@ -112,6 +62,9 @@ export default function ChatToolsModal({
                   </div>
                   <div className="text-xs text-chrome-text-secondary mt-1">
                     {metadata.description}
+                  </div>
+                  <div className="text-xs mt-1 text-chrome-text-secondary">
+                    {alwaysAllow ? "Always allowed" : "Asks each time"}
                   </div>
                 </label>
               </div>
@@ -122,22 +75,11 @@ export default function ChatToolsModal({
         <div className="flex justify-end gap-2 pt-4 border-t border-chrome-border">
           <Button
             type="button"
-            variant="ghost"
-            color="secondary"
-            onClick={onClose}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
             variant="solid"
             color="primary"
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-            loading={isSubmitting}
+            onClick={onClose}
           >
-            Apply Changes
+            Done
           </Button>
         </div>
       </div>

--- a/src/sidebar/chat/CopyButton.tsx
+++ b/src/sidebar/chat/CopyButton.tsx
@@ -1,0 +1,56 @@
+import { Check, Copy } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import cn from "../utils/classnames.ts";
+
+export default function CopyButton({
+  text,
+  align,
+  anchor,
+}: {
+  text: string;
+  align: "left" | "right";
+  anchor: string;
+}) {
+  const [copied, setCopied] = useState(false);
+  const timeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+    };
+  }, []);
+
+  const onClick = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      if (timeoutRef.current) clearTimeout(timeoutRef.current);
+      timeoutRef.current = setTimeout(() => setCopied(false), 1200);
+    } catch (error) {
+      console.warn("Copy failed:", error);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={copied ? "Copied" : "Copy message"}
+      title={copied ? "Copied" : "Copy"}
+      disabled={!text}
+      className={cn(
+        "copy-button",
+        align === "left" ? "copy-button-left" : "copy-button-right",
+        "inline-flex items-center gap-1 rounded px-1.5 py-1 text-[11px] text-chrome-text-secondary transition-colors hover:bg-chrome-hover hover:text-chrome-text-primary cursor-pointer"
+      )}
+      style={{ positionAnchor: anchor } as React.CSSProperties}
+    >
+      {copied ? (
+        <Check className="h-3 w-3" />
+      ) : (
+        <Copy className="h-3 w-3" />
+      )}
+    </button>
+  );
+}

--- a/src/sidebar/chat/MessageContent.tsx
+++ b/src/sidebar/chat/MessageContent.tsx
@@ -1,25 +1,40 @@
+import { memo } from "react";
 import showdown from "showdown";
 
-import { type AgentMetrics, type ChatMessageTool } from "../../shared/types.ts";
+import {
+  type AgentMetrics,
+  type ChatMessageTool,
+  type ToolPermissionDecision,
+} from "../../shared/types.ts";
 import { Loader } from "../theme";
 import MessageToolCall from "./MessageToolCall.tsx";
 
 const converter = new showdown.Converter();
 
-export default function MessageContent({
+function MessageContent({
   content,
   tools = [],
   metrics,
+  onPermissionDecision,
 }: {
   content: string;
   tools: Array<ChatMessageTool>;
   metrics: AgentMetrics;
+  onPermissionDecision: (
+    toolCallId: string,
+    decision: ToolPermissionDecision
+  ) => void;
 }) {
   const showMetrics = metrics.tokensPerSecond > 0;
 
   return (
     <div className="space-y-3">
-      {tools && tools.length > 0 && <MessageToolCall tools={tools} />}
+      {tools && tools.length > 0 && (
+        <MessageToolCall
+          tools={tools}
+          onPermissionDecision={onPermissionDecision}
+        />
+      )}
       {Boolean(content) ? (
         <>
           <div
@@ -42,3 +57,26 @@ export default function MessageContent({
     </div>
   );
 }
+
+// Chrome IPC structurally clones messages, so every token gives identical-by-value
+// but different-by-reference props. Compare by value to avoid re-renders that
+// would replay dangerouslySetInnerHTML and wipe the user's text selection.
+export default memo(MessageContent, (prev, next) => {
+  if (prev.content !== next.content) return false;
+  if (prev.onPermissionDecision !== next.onPermissionDecision) return false;
+  if (prev.metrics.tokensPerSecond !== next.metrics.tokensPerSecond)
+    return false;
+  if (prev.tools.length !== next.tools.length) return false;
+  for (let i = 0; i < prev.tools.length; i++) {
+    const a = prev.tools[i];
+    const b = next.tools[i];
+    if (
+      a.id !== b.id ||
+      a.status !== b.status ||
+      a.result !== b.result ||
+      a.functionSignature !== b.functionSignature
+    )
+      return false;
+  }
+  return true;
+});

--- a/src/sidebar/chat/MessageToolCall.tsx
+++ b/src/sidebar/chat/MessageToolCall.tsx
@@ -1,15 +1,31 @@
-import { ChevronLeft, ChevronRight, Wrench } from "lucide-react";
+import { Ban, Check, ChevronLeft, ChevronRight, Wrench } from "lucide-react";
 import { useState } from "react";
 
-import { ChatMessageTool } from "../../shared/types.ts";
+import { getToolLabel } from "../../shared/tools.ts";
+import {
+  ChatMessageTool,
+  ToolPermissionDecision,
+} from "../../shared/types.ts";
 import { Loader } from "../theme";
 import cn from "../utils/classnames.ts";
 
+const statusLabel: Record<ChatMessageTool["status"], string> = {
+  pending_permission: "approve tool call",
+  running: "calling tool",
+  completed: "called tool",
+  denied: "denied tool",
+};
+
 export default function MessageToolCall({
   tools,
+  onPermissionDecision,
   className = "",
 }: {
   tools: Array<ChatMessageTool>;
+  onPermissionDecision: (
+    toolCallId: string,
+    decision: ToolPermissionDecision
+  ) => void;
   className?: string;
 }) {
   const [currentToolIndex, setCurrentToolIndex] = useState(0);
@@ -24,7 +40,9 @@ export default function MessageToolCall({
   };
 
   const activeTool = tools[currentToolIndex];
-  const isLoading = activeTool.result === "";
+  const isLoading = activeTool.status === "running";
+  const isPending = activeTool.status === "pending_permission";
+  const isDenied = activeTool.status === "denied";
 
   return (
     <div
@@ -38,8 +56,15 @@ export default function MessageToolCall({
           className="flex items-center gap-2 text-xs cursor-pointer"
           onClick={() => setExpanded(!expanded)}
         >
-          {isLoading ? <Loader size="xs" /> : <Wrench className="h-3 w-3" />}
-          {isLoading ? "calling tool" : "called tool"} <b>{activeTool.name}</b>
+          {isLoading ? (
+            <Loader size="xs" />
+          ) : isDenied ? (
+            <Ban className="h-3 w-3 text-chrome-text-secondary" />
+          ) : (
+            <Wrench className="h-3 w-3" />
+          )}
+          {statusLabel[activeTool.status]}{" "}
+          <b>{getToolLabel(activeTool.name)}</b>
         </button>
         {tools.length > 1 && (
           <div className="flex items-center gap-1">
@@ -71,6 +96,37 @@ export default function MessageToolCall({
           </div>
         )}
       </div>
+      {isPending && (
+        <div className="mt-3 space-y-2">
+          <code className="text-xs bg-chrome-bg-primary px-2 py-1 rounded block text-chrome-accent-primary font-mono overflow-hidden">
+            {activeTool.functionSignature}
+          </code>
+          <div className="flex flex-wrap gap-2">
+            <button
+              onClick={() =>
+                onPermissionDecision(activeTool.id, "allow_once")
+              }
+              className="inline-flex items-center gap-1 rounded bg-chrome-accent-primary px-2.5 py-1 text-xs font-medium text-chrome-bg-primary hover:bg-chrome-accent-hover cursor-pointer"
+            >
+              <Check className="h-3 w-3" /> Allow once
+            </button>
+            <button
+              onClick={() =>
+                onPermissionDecision(activeTool.id, "always_allow")
+              }
+              className="inline-flex items-center gap-1 rounded border border-chrome-accent-primary px-2.5 py-1 text-xs font-medium text-chrome-accent-primary hover:bg-chrome-hover cursor-pointer"
+            >
+              Always allow {getToolLabel(activeTool.name)}
+            </button>
+            <button
+              onClick={() => onPermissionDecision(activeTool.id, "deny")}
+              className="inline-flex items-center gap-1 rounded border border-chrome-border px-2.5 py-1 text-xs font-medium text-chrome-text-secondary hover:bg-chrome-hover cursor-pointer"
+            >
+              <Ban className="h-3 w-3" /> Deny
+            </button>
+          </div>
+        </div>
+      )}
       {expanded && (
         <div className="space-y-2 mt-2">
           <div>

--- a/src/sidebar/components/SettingsHeader.tsx
+++ b/src/sidebar/components/SettingsHeader.tsx
@@ -11,7 +11,7 @@ export default function SettingsHeader({
     <header
       className={cn(
         className,
-        "border-b border-chrome-border bg-chrome-bg-primary px-6 py-4"
+        "select-none border-b border-chrome-border bg-chrome-bg-primary px-6 py-4"
       )}
     >
       <div className="flex items-center justify-between">

--- a/src/sidebar/index.css
+++ b/src/sidebar/index.css
@@ -58,3 +58,52 @@ body {
   background-color: #202124;
   color: #e8eaed;
 }
+
+.user-message ::selection,
+.user-message::selection {
+  background-color: var(--color-chrome-bg-primary);
+  color: var(--color-chrome-accent-primary);
+}
+
+.message-bubble {
+  border-radius: var(--radius-lg);
+}
+@supports (corner-shape: bevel) {
+  .message-bubble {
+    border-radius: var(--radius-lg);
+    corner-shape: squircle;
+  }
+}
+
+.copy-button {
+  position: absolute;
+  bottom: anchor(bottom);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.15s;
+}
+.copy-button-left {
+  right: calc(anchor(left) + 4px);
+}
+.copy-button-right {
+  left: calc(anchor(right) + 4px);
+}
+.message-row:hover .copy-button,
+.copy-button:focus-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+/* Fallback for browsers without anchor positioning. */
+@supports not (anchor-name: --x) {
+  .message-row {
+    display: flex;
+    align-items: flex-end;
+    gap: 4px;
+  }
+  .copy-button {
+    position: static;
+  }
+  .copy-button-left {
+    order: -1;
+  }
+}


### PR DESCRIPTION
Hi there,

I discovered this extension today via Twitter. Great work! 

I thought it could benefit from a bit of interface polish. The improvements concern the chat sidebar, plus the underlying agent infrastructure they rely on.


**Agent**
- Stop button cancels in-progress generation via `InterruptableStoppingCriteria`; KV cache is disposed if interrupted to avoid GPU buffer corruption on the next run.
- Each tool call is now gated by an inline **Allow once / Always allow / Deny** prompt rendered in the message itself. Decisions persist per tool name in `chrome.storage.local`. Cancelling resolves any pending permission prompts as denied (for context I find it hard to know which tools to enable ahead of a session and which not, and if the agent just complains it can't do the job that's not helpful)
- The system prompt is refreshed each turn with the active tab's title + URL, so the model can resolve "this page" references without the user pasting URLs (probably the most common use case).

**ask_website fix**
- Falls back to `chrome.scripting.executeScript({ files: ["content.js"] })` when the content script isn't present (e.g. tabs that predate an extension reload), then retries.

**Chat UI**
- Input redesigned as a single bordered textarea with auto-resize (max 10 lines), inline **Tools** label and **↵** send glyph, generous hitboxes with hover-only chip backgrounds.
- Cancel button replaces send while generating.
- Header and input chrome are non-selectable so Cmd+A doesn't grab the placeholder or "Tools" label; textarea retains its native selection.
- Auto-scroll yields to active text selection / mouse-down / scroll-up; `MessageContent` is memoized with a value-based comparator so prior messages survive Chrome's IPC re-cloning intact.
- Squircle-shaped bubbles via `corner-shape: squircle` with a sensible fallback.
- Distinct selection color inside user (blue) bubbles. (was previously not visible)
- Hover-only **Copy** button outside the bubble (anchor-positioned to the bottom-left for user messages, bottom-right for assistant). Falls back to a flex layout in browsers without anchor positioning.

**Tools modal repurposed**
- Now a permission manager — toggle "Always allow" per tool. Drops the no-op `activeTools` storage that was previously not wired through to the agent.

---

Happy to split this into 5 separate PRs, one per commit, if you'd prefer to review them in isolation. let me know!