### PR TITLE
fix: add askWebsite retry schedule

### DIFF
--- a/src/background/tools/askWebsite.ts
+++ b/src/background/tools/askWebsite.ts
@@ -91,13 +91,27 @@ class WebsiteContentManager {
       tabId = tab.id;
     }
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
+    let response: { parts: Array<WebsitePart> } | null = null;
+    const maxRetries = 5;
+    for (let attempt = 0; attempt < maxRetries; attempt++) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, 200 * Math.pow(2, attempt))
+      );
+      try {
+        response = await chrome.tabs.sendMessage(tabId, {
+          type: ContentTasks.EXTRACT_PAGE_DATA,
+        });
+        break;
+      } catch {
+        if (attempt === maxRetries - 1) {
+          throw new Error(
+            "Could not connect to page content script after multiple retries"
+          );
+        }
+      }
+    }
 
-    const response = await chrome.tabs.sendMessage(tabId, {
-      type: ContentTasks.EXTRACT_PAGE_DATA,
-    });
-
-    const parts = response.parts as Array<WebsitePart>;
+    const parts = response!.parts as Array<WebsitePart>;
 
     await Promise.all(
       parts.map(async (part, i) => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />


### PR DESCRIPTION
Summary:
This fix addresses a reliability issue when the askWebsite tool tries to communicate with a Chrome tab's content script to extract page data.

Problem:
The previous implementation used a single fixed 500ms delay before sending the EXTRACT_PAGE_DATA message to the content script. This was fragile — if the content script wasn't ready yet (e.g., the page was still loading or the script hadn't finished injecting), the call would simply fail with no recovery.

Solution:
Replaced the one-shot delay with an exponential backoff retry schedule:
- Up to 5 attempts are made to reach the content script.
- Wait time between attempts grows exponentially: 200ms × 2^attempt (200ms → 400ms → 800ms → 1600ms → 3200ms).
- Errors on each attempt are caught and retried silently.
- If all attempts are exhausted, a descriptive error is thrown: "Could not connect to page content script after multiple retries".

Changes:
src/background/tools/askWebsite.ts — replaced fixed delay with retry loop using exponential backoff.
src/vite-env.d.ts — added missing Vite client type reference.