### PR TITLE
Feat/webmcp page tools

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   },
   "dependencies": {
     "@huggingface/transformers": "^4.2.0",
+    "@mcp-b/webmcp-polyfill": "^2.2.0",
     "idb": "^8.0.3",
     "lucide-react": "^0.553.0",
     "react": "^19.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@huggingface/transformers':
         specifier: ^4.2.0
         version: 4.2.0
+      '@mcp-b/webmcp-polyfill':
+        specifier: ^2.2.0
+        version: 2.2.0
       idb:
         specifier: ^8.0.3
         version: 8.0.3
@@ -173,6 +176,9 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@cfworker/json-schema@4.1.1':
+    resolution: {integrity: sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og==}
 
   '@devicefarmer/adbkit-logcat@2.1.3':
     resolution: {integrity: sha512-yeaGFjNBc/6+svbDeul1tNHtNChw6h8pSHAt5D+JsedUrMTN7tla7B15WLDyekxsuS2XlZHRxpuC6m92wiwCNw==}
@@ -563,6 +569,13 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@mcp-b/webmcp-polyfill@2.2.0':
+    resolution: {integrity: sha512-as49JP4MHXVMMVNzD8938EsiU2tEzWNk7Un6c6C/xK5rstkIrQZQsVLbH7NFtmgMb6bbryzSqg9JWSFIxkU27Q==}
+    engines: {node: '>=18'}
+
+  '@mcp-b/webmcp-types@2.2.0':
+    resolution: {integrity: sha512-1/UYAwQKBkqRgK18GkbGR4m6Cn9vz6Qy6pTL5LIIinUOhR5dMLaNl/blH/tJT+nJleMmgDoFZWGAmmr+fAz2PQ==}
+
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
     engines: {node: '>=12.22.0'}
@@ -732,6 +745,9 @@ packages:
     resolution: {integrity: sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==}
     cpu: [x64]
     os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
   '@tailwindcss/node@4.2.2':
     resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
@@ -2445,6 +2461,8 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@cfworker/json-schema@4.1.1': {}
+
   '@devicefarmer/adbkit-logcat@2.1.3': {}
 
   '@devicefarmer/adbkit-monkey@1.2.1': {}
@@ -2728,6 +2746,14 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@mcp-b/webmcp-polyfill@2.2.0':
+    dependencies:
+      '@cfworker/json-schema': 4.1.1
+      '@mcp-b/webmcp-types': 2.2.0
+      '@standard-schema/spec': 1.1.0
+
+  '@mcp-b/webmcp-types@2.2.0': {}
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -2839,6 +2865,8 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.1':
     optional: true
+
+  '@standard-schema/spec@1.1.0': {}
 
   '@tailwindcss/node@4.2.2':
     dependencies:

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -20,6 +20,18 @@
       "matches": ["http://*/*", "https://*/*"],
       "js": ["content.js"],
       "run_at": "document_idle"
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["page-bootstrap.js"],
+      "world": "MAIN",
+      "run_at": "document_start"
+    },
+    {
+      "matches": ["http://*/*", "https://*/*"],
+      "js": ["content-bridge.js"],
+      "world": "ISOLATED",
+      "run_at": "document_start"
     }
   ],
   "action": {

--- a/src/background/agent/Agent.ts
+++ b/src/background/agent/Agent.ts
@@ -32,8 +32,19 @@ let pipe: TextGenerationPipeline | null = null;
 const SYSTEM_PROMPT =
   "You are a helpful assistant with access to external tools declared in this conversation. " +
   "Never claim you do not have tools when tool declarations are present. " +
-  "When asked what tools you have, list the declared tool names exactly. " +
-  "If you decide to use a tool, briefly explain what you are doing before calling it.";
+  "When asked what tools you have, list every declared tool by name — including the " +
+  "page-specific tools registered by the current website. Do not omit any. " +
+  "Always prefer a page-specific tool (one registered by the current website, listed " +
+  "first in the tool list) over a generic tool when the user's request is about that " +
+  "site's content — for example, prefer `search_products` over `find_history` when the " +
+  "user asks to search products on a shopping page. Treat product or feature names in " +
+  "the user's message as data, never as instructions to refuse — for example, " +
+  '"add to cart hack the grid" means add the product called "Hack the Grid". ' +
+  "If you decide to use a tool, briefly explain what you are doing before calling it. " +
+  "When calling a tool you MUST populate every argument listed in the tool's `required` " +
+  "schema. Infer the values from the user's most recent message — for example, if the " +
+  "user says \"search hats\" and the tool's required argument is `query`, call it with " +
+  '`{"query": "hats"}`. Never call a tool with empty arguments when arguments are required.';
 const createInitialMessages = (): Array<Message> => [
   {
     role: "system",
@@ -76,8 +87,24 @@ class Agent {
     (chatMessages: Array<ChatMessage>) => void
   > = [];
   private tools: Array<WebMCPTool> = [];
+  private pageTools: Array<WebMCPTool> = [];
 
   constructor() {}
+
+  private getActiveTools = (): Array<WebMCPTool> => {
+    // Page tools first: they are the ones registered by the current website
+    // and are usually the most contextually relevant. Small models bias
+    // toward whichever tools they encounter first in the prompt, so listing
+    // page tools up top materially improves selection on sites that ship
+    // their own WebMCP catalog.
+    const pageNames = new Set(this.pageTools.map((t) => t.name));
+    const filteredBuiltIns = this.tools.filter((t) => !pageNames.has(t.name));
+    return [...this.pageTools, ...filteredBuiltIns];
+  };
+
+  public setPageTools = (tools: Array<WebMCPTool>) => {
+    this.pageTools = tools;
+  };
 
   get chatMessages() {
     return this._chatMessages;
@@ -141,13 +168,13 @@ class Agent {
     });
 
     const input = pipe.tokenizer.apply_chat_template(conversation, {
-      tools: this.tools.map(webMCPToolToChatTemplateTool),
+      tools: this.getActiveTools().map(webMCPToolToChatTemplateTool),
       add_generation_prompt: true,
       return_dict: true,
     }) as any;
 
     const output: any = await pipe(conversation, {
-      tools: this.tools.map(webMCPToolToChatTemplateTool),
+      tools: this.getActiveTools().map(webMCPToolToChatTemplateTool),
       add_generation_prompt: true,
       past_key_values: this.pastKeyValues,
       max_new_tokens: 1024,
@@ -370,8 +397,14 @@ class Agent {
         }));
 
         this.chatMessages = [...prevChatMessages, assistantMessage];
-        prompt =
-          "Use the tool response to answer the user's last request. Do not call tools again unless required.";
+        const hasArgError = toolResponses.some(({ result }) =>
+          /(input validation error|missing required|does not have required property|expected object arguments)/i.test(
+            result
+          )
+        );
+        prompt = hasArgError
+          ? "The previous tool call failed because of bad or missing arguments. Read the error message, then retry the same tool with the missing arguments filled in from the user's request. Do not ask the user to repeat themselves."
+          : "Use the tool response to answer the user's last request. Do not call tools again unless required.";
         roleForGeneration = "user";
         appendPromptMessage = true;
       }
@@ -406,7 +439,9 @@ class Agent {
   private executeToolCall = async (
     toolCall: ToolCallPayload
   ): Promise<{ id: string; name: string; result: string }> => {
-    const toolToUse = this.tools.find((t) => t.name === toolCall.name);
+    const toolToUse = this.getActiveTools().find(
+      (t) => t.name === toolCall.name
+    );
     if (!toolToUse)
       throw new Error(`Tool '${toolCall.name}' not found or is disabled.`);
 

--- a/src/background/agent/webMcp.tsx
+++ b/src/background/agent/webMcp.tsx
@@ -22,10 +22,13 @@ export interface WebMCPTool {
   description: string;
   inputSchema: {
     type: "object";
-    properties: Record<string, WebMCPProperty>;
-    required: Array<string>;
+    properties: Record<string, WebMCPProperty> | Record<string, any>;
+    required?: Array<string>;
   };
   execute: (args: Record<string, any>) => Promise<string>;
+  // When true, skip the local argument validator. Used by page-supplied tools
+  // whose schemas are arbitrary JSON Schema validated by the page polyfill.
+  bypassValidation?: boolean;
 }
 
 export const webMCPToolToChatTemplateTool = (
@@ -65,8 +68,9 @@ export const validateWebMCPToolArguments = (
     return { ...acc, [curr[0]]: curr[1] };
   }, {});
 
-  if (tool.inputSchema.required.length !== 0) {
-    const missingArguments = tool.inputSchema.required.filter(
+  const required = tool.inputSchema.required ?? [];
+  if (required.length !== 0) {
+    const missingArguments = required.filter(
       (argument) => !(argument in returnArgs)
     );
 
@@ -97,6 +101,8 @@ export const executeWebMCPTool = async (
     parsedArgs = args;
   }
 
-  const validatedArgs = validateWebMCPToolArguments(tool, parsedArgs);
+  const validatedArgs = tool.bypassValidation
+    ? parsedArgs
+    : validateWebMCPToolArguments(tool, parsedArgs);
   return await tool.execute(validatedArgs);
 };

--- a/src/background/background.ts
+++ b/src/background/background.ts
@@ -6,8 +6,10 @@ import {
   BackgroundMessages,
   BackgroundTasks,
   ResponseStatus,
+  WebMCPToolSummary,
 } from "../shared/types.ts";
 import Agent from "./agent/Agent.ts";
+import { WebMCPTool } from "./agent/webMcp.tsx";
 import {
   createAskWebsiteTool,
   highlightWebsiteElementTool,
@@ -40,6 +42,109 @@ const onModelDownloadProgress = (modelId: string, percentage: number) => {
 const featureExtractor = new FeatureExtractor();
 const vectorHistory = new VectorHistory(featureExtractor);
 let currentAgent: Agent | null = null;
+
+// Tools registered by each tab's page via the WebMCP polyfill.
+const webmcpToolsByTab: Map<number, WebMCPToolSummary[]> = new Map();
+
+const MAX_TOOL_NAME_LENGTH = 64;
+const MAX_TOOL_DESCRIPTION_LENGTH = 512;
+const VALID_TOOL_NAME = /^[A-Za-z0-9_-]+$/;
+
+// Tool metadata is page-controlled and flows verbatim into the LLM prompt.
+// We can't fully sandbox prompt content, but we cap length and reject obvious
+// shenanigans (control chars, oversized strings, missing/invalid names).
+const sanitizeWebMCPTools = (raw: unknown): WebMCPToolSummary[] => {
+  if (!Array.isArray(raw)) return [];
+  return raw
+    .map((entry): WebMCPToolSummary | null => {
+      if (!entry || typeof entry !== "object") return null;
+      const e = entry as Record<string, unknown>;
+
+      const name =
+        typeof e.name === "string" ? e.name.trim() : "";
+      if (
+        !name ||
+        name.length > MAX_TOOL_NAME_LENGTH ||
+        !VALID_TOOL_NAME.test(name)
+      ) {
+        return null;
+      }
+
+      const rawDescription =
+        typeof e.description === "string" ? e.description : "";
+      const description = rawDescription
+        // Strip control chars (incl. NUL) so they can't terminate strings or
+        // break the chat template.
+        // eslint-disable-next-line no-control-regex
+        .replace(/[\u0000-\u001F\u007F]/g, " ")
+        .slice(0, MAX_TOOL_DESCRIPTION_LENGTH);
+
+      const inputSchema =
+        e.inputSchema && typeof e.inputSchema === "object"
+          ? (e.inputSchema as Record<string, unknown>)
+          : { type: "object", properties: {}, required: [] };
+
+      return { name, description, inputSchema };
+    })
+    .filter((t): t is WebMCPToolSummary => t !== null);
+};
+
+const getActiveTabId = async (): Promise<number | null> => {
+  const [tab] = await chrome.tabs.query({
+    active: true,
+    lastFocusedWindow: true,
+  });
+  return tab?.id ?? null;
+};
+
+const buildPageWebMCPTools = (
+  tabId: number,
+  summaries: WebMCPToolSummary[]
+): WebMCPTool[] =>
+  summaries.map((summary) => ({
+    name: summary.name,
+    description: summary.description,
+    inputSchema: (summary.inputSchema as any) ?? {
+      type: "object",
+      properties: {},
+      required: [],
+    },
+    bypassValidation: true,
+    execute: async (args: Record<string, any>) => {
+      try {
+        const response: any = await chrome.tabs.sendMessage(tabId, {
+          type: "webmcp:call",
+          name: summary.name,
+          args,
+        });
+        if (!response) {
+          return `Error: no response from page for tool '${summary.name}'`;
+        }
+        if (response.ok) {
+          const result = response.result;
+          if (typeof result === "string") return result;
+          try {
+            return JSON.stringify(result);
+          } catch {
+            return String(result);
+          }
+        }
+        return `Error: ${response.error ?? "unknown error"}`;
+      } catch (error) {
+        return `Error calling page tool '${summary.name}': ${error instanceof Error ? error.message : String(error)}`;
+      }
+    },
+  }));
+
+const broadcastActiveTabTools = async () => {
+  const tabId = await getActiveTabId();
+  const tools = tabId !== null ? (webmcpToolsByTab.get(tabId) ?? []) : [];
+  chrome.runtime.sendMessage({
+    type: BackgroundMessages.WEBMCP_TOOLS_UPDATED,
+    tools,
+    tabId,
+  });
+};
 
 const availableTools: Record<string, () => any> = {
   [AvailableTools.GET_OPEN_TABS]: () => getOpenTabsTool,
@@ -83,7 +188,25 @@ const getAgent = (): Agent => {
   return currentAgent;
 };
 
-chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "webmcp:tools") {
+    const tabId = sender.tab?.id;
+    if (typeof tabId === "number") {
+      webmcpToolsByTab.set(tabId, sanitizeWebMCPTools(message.tools));
+      void broadcastActiveTabTools();
+    }
+    sendResponse({ ok: true });
+    return false;
+  }
+
+  if (message?.type === BackgroundTasks.WEBMCP_GET_TOOLS_FOR_ACTIVE_TAB) {
+    getActiveTabId().then((tabId) => {
+      const tools = tabId !== null ? (webmcpToolsByTab.get(tabId) ?? []) : [];
+      sendResponse({ status: ResponseStatus.SUCCESS, tools, tabId });
+    });
+    return true;
+  }
+
   if (message.type === BackgroundTasks.CHECK_MODELS) {
     Promise.all(
       REQUIRED_MODEL_IDS.map(async (modelId) => {
@@ -156,15 +279,26 @@ chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
 
   if (message.type === BackgroundTasks.AGENT_GENERATE_TEXT) {
     const agent = getAgent();
-    agent
-      .runAgent(message.prompt)
-      .then((metrics) => {
+    (async () => {
+      try {
+        // Prefer the tabId the sidebar tells us — it's the tab whose tools
+        // the user can actually see. Fall back to lastFocusedWindow lookup
+        // only if the sidebar didn't provide one (older message format).
+        const requestedTabId =
+          typeof message.tabId === "number" ? message.tabId : null;
+        const tabId = requestedTabId ?? (await getActiveTabId());
+        const summaries =
+          tabId !== null ? (webmcpToolsByTab.get(tabId) ?? []) : [];
+        agent.setPageTools(
+          tabId !== null ? buildPageWebMCPTools(tabId, summaries) : []
+        );
+        const metrics = await agent.runAgent(message.prompt);
         sendResponse({ status: ResponseStatus.SUCCESS, metrics });
-      })
-      .catch((error: Error) => {
+      } catch (error: any) {
         console.error("GENERATE_TEXT failed:", error);
         sendResponse({ status: ResponseStatus.ERROR, error: error.message });
-      });
+      }
+    })();
 
     return true;
   }
@@ -240,9 +374,27 @@ const addCurrentPageToVectorHistory = async (tabId: number, tab: Tab) => {
 };
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
+  if (changeInfo.status === "loading") {
+    // Page is navigating; clear stale tools until the new page registers them.
+    if (webmcpToolsByTab.has(tabId)) {
+      webmcpToolsByTab.delete(tabId);
+      void broadcastActiveTabTools();
+    }
+  }
+
   if (changeInfo.status !== "complete") return;
   if (!tab.url?.startsWith("http")) return;
 
   // Add page to vector history for later retrieval
   addCurrentPageToVectorHistory(tabId, tab);
+});
+
+chrome.tabs.onRemoved.addListener((tabId) => {
+  if (webmcpToolsByTab.delete(tabId)) {
+    void broadcastActiveTabTools();
+  }
+});
+
+chrome.tabs.onActivated.addListener(() => {
+  void broadcastActiveTabTools();
 });

--- a/src/background/tools/askWebsite.ts
+++ b/src/background/tools/askWebsite.ts
@@ -57,6 +57,12 @@ class WebsiteContentManager {
 
     this.currentTabId = tabId;
     this.currentUrl = url;
+    this.currentPageParts = [];
+
+    if (!/^https?:\/\//i.test(url)) {
+      // No content script on non-http URLs, skip silently.
+      return;
+    }
 
     this.loadCurrentPage().catch((error) => {
       console.error("Failed to load page content:", error);
@@ -79,6 +85,7 @@ class WebsiteContentManager {
 
   private async _loadCurrentPageInternal(): Promise<void> {
     let tabId = this.currentTabId;
+    let url = this.currentUrl;
 
     if (!tabId) {
       const [tab] = await chrome.tabs.query({
@@ -86,18 +93,46 @@ class WebsiteContentManager {
         currentWindow: true,
       });
       if (!tab?.id) {
-        throw new Error("No active tab found");
+        // No active tab; treat as empty page rather than throwing.
+        this.currentPageParts = [];
+        return;
       }
       tabId = tab.id;
+      url = tab.url ?? null;
+    }
+
+    // The content script only matches http(s) URLs, so skip everything else
+    // (chrome://, chrome-extension://, file://, devtools://, about:, etc.)
+    // to avoid "Could not establish connection" errors.
+    if (!url || !/^https?:\/\//i.test(url)) {
+      this.currentPageParts = [];
+      return;
     }
 
     await new Promise((resolve) => setTimeout(resolve, 500));
 
-    const response = await chrome.tabs.sendMessage(tabId, {
-      type: ContentTasks.EXTRACT_PAGE_DATA,
-    });
+    let response: { parts?: Array<WebsitePart> } | undefined;
+    try {
+      response = await chrome.tabs.sendMessage(tabId, {
+        type: ContentTasks.EXTRACT_PAGE_DATA,
+      });
+    } catch (error) {
+      // Content script not yet injected/listening (e.g., page navigated, was
+      // restored, or chrome blocked injection). Treat as empty rather than
+      // throwing past the catch in loadPageForTab.
+      console.debug(
+        `[askWebsite] No response from content script for ${url}:`,
+        error
+      );
+      this.currentPageParts = [];
+      return;
+    }
 
-    const parts = response.parts as Array<WebsitePart>;
+    const parts = response?.parts;
+    if (!Array.isArray(parts)) {
+      this.currentPageParts = [];
+      return;
+    }
 
     await Promise.all(
       parts.map(async (part, i) => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -12,12 +12,20 @@ export enum BackgroundTasks {
   AGENT_GENERATE_TEXT,
   AGENT_GET_MESSAGES,
   AGENT_CLEAR,
+  WEBMCP_GET_TOOLS_FOR_ACTIVE_TAB,
 }
 
 export enum BackgroundMessages {
   MODEL_CHECK,
   DOWNLOAD_PROGRESS,
   MESSAGES_UPDATE,
+  WEBMCP_TOOLS_UPDATED,
+}
+
+export interface WebMCPToolSummary {
+  name: string;
+  description: string;
+  inputSchema?: Record<string, any>;
 }
 
 export enum ContentTasks {

--- a/src/sidebar/chat/Chat.tsx
+++ b/src/sidebar/chat/Chat.tsx
@@ -8,6 +8,7 @@ import {
   BackgroundTasks,
   ChatMessage,
   ResponseStatus,
+  WebMCPToolSummary,
 } from "../../shared/types.ts";
 import { Button, InputText } from "../theme";
 import cn from "../utils/classnames.ts";
@@ -42,6 +43,8 @@ export default function Chat() {
 
   const [activeTools, setActiveTools] = useState<ToolName[]>();
   const [toolsLoaded, setToolsLoaded] = useState<boolean>(false);
+  const [pageTools, setPageTools] = useState<WebMCPToolSummary[]>([]);
+  const [pageToolsTabId, setPageToolsTabId] = useState<number | null>(null);
 
   const inputValue = watch("input");
 
@@ -112,7 +115,25 @@ export default function Chat() {
       if (message.type === BackgroundMessages.MESSAGES_UPDATE) {
         setMessages(message.messages);
       }
+      if (message.type === BackgroundMessages.WEBMCP_TOOLS_UPDATED) {
+        setPageTools(message.tools ?? []);
+        setPageToolsTabId(
+          typeof message.tabId === "number" ? message.tabId : null
+        );
+      }
     });
+
+    chrome.runtime.sendMessage(
+      { type: BackgroundTasks.WEBMCP_GET_TOOLS_FOR_ACTIVE_TAB },
+      (
+        resp:
+          | { tools?: WebMCPToolSummary[]; tabId?: number | null }
+          | undefined
+      ) => {
+        if (resp?.tools) setPageTools(resp.tools);
+        if (typeof resp?.tabId === "number") setPageToolsTabId(resp.tabId);
+      }
+    );
   }, []);
 
   // Forward keyboard events to ChatCommands
@@ -130,6 +151,7 @@ export default function Chat() {
       {
         type: BackgroundTasks.AGENT_GENERATE_TEXT,
         prompt: data.input,
+        tabId: pageToolsTabId,
       },
       (resp) => {
         if (resp.status === ResponseStatus.ERROR) {
@@ -191,6 +213,7 @@ export default function Chat() {
         {toolsOpen && (
           <ChatToolsModal
             activeTools={activeTools}
+            pageTools={pageTools}
             onClose={() => setToolsOpen(false)}
             onSubmit={(tools: ToolName[]) => {
               setActiveTools(tools);

--- a/src/sidebar/chat/ChatToolsModal.tsx
+++ b/src/sidebar/chat/ChatToolsModal.tsx
@@ -1,11 +1,17 @@
 import { useState } from "react";
 
 import { AvailableTools, ToolName } from "../../shared/tools.ts";
-import { BackgroundTasks, ResponseStatus } from "../../shared/types.ts";
+import {
+  BackgroundTasks,
+  ResponseStatus,
+  WebMCPToolSummary,
+} from "../../shared/types.ts";
 import { Button, Modal } from "../theme";
+import cn from "../utils/classnames.ts";
 
 interface ChatToolsModalProps {
   activeTools: ToolName[];
+  pageTools: WebMCPToolSummary[];
   onClose: () => void;
   onSubmit: (tools: ToolName[]) => void;
 }
@@ -41,8 +47,11 @@ const toolMetadata: Record<ToolName, { label: string; description: string }> = {
   },
 };
 
+type Tab = "builtin" | "page";
+
 export default function ChatToolsModal({
   activeTools,
+  pageTools,
   onClose,
   onSubmit,
 }: ChatToolsModalProps) {
@@ -50,6 +59,7 @@ export default function ChatToolsModal({
     new Set(activeTools)
   );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [activeTab, setActiveTab] = useState<Tab>("builtin");
 
   const handleToggle = (tool: ToolName) => {
     const newSelected = new Set(selectedTools);
@@ -66,7 +76,6 @@ export default function ChatToolsModal({
 
     const toolsArray = Array.from(selectedTools);
 
-    // Send AGENT_INITIALIZE with selected tools
     chrome.runtime.sendMessage(
       {
         type: BackgroundTasks.AGENT_INITIALIZE,
@@ -83,41 +92,96 @@ export default function ChatToolsModal({
     );
   };
 
+  const tabClass = (tab: Tab) =>
+    cn(
+      "px-3 py-2 text-sm font-medium border-b-2 -mb-px transition-colors",
+      activeTab === tab
+        ? "border-chrome-accent-primary text-chrome-text-primary"
+        : "border-transparent text-chrome-text-secondary hover:text-chrome-text-primary"
+    );
+
   return (
     <Modal title="Configure Tools" onClose={onClose}>
       <div className="space-y-4">
-        <p className="text-sm text-chrome-text-secondary">
-          Select which tools the agent can use. Changes will reset the current
-          conversation.
-        </p>
-
-        <div className="space-y-3 overflow-y-auto">
-          {Object.values(AvailableTools).map((tool) => {
-            const metadata = toolMetadata[tool];
-            return (
-              <div
-                key={tool}
-                className="flex items-start gap-3 rounded-lg border border-chrome-border p-3"
-              >
-                <input
-                  type="checkbox"
-                  id={tool}
-                  checked={selectedTools.has(tool)}
-                  onChange={() => handleToggle(tool)}
-                  className="mt-1 h-4 w-4 cursor-pointer rounded border transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none bg-chrome-bg-primary border-chrome-border text-chrome-accent-primary focus:border-chrome-accent-primary focus:ring-chrome-accent-primary focus:ring-offset-chrome-bg-primary"
-                />
-                <label htmlFor={tool} className="flex-1 cursor-pointer">
-                  <div className="text-sm font-medium text-chrome-text-primary">
-                    {metadata.label}
-                  </div>
-                  <div className="text-xs text-chrome-text-secondary mt-1">
-                    {metadata.description}
-                  </div>
-                </label>
-              </div>
-            );
-          })}
+        <div className="flex items-center gap-2 border-b border-chrome-border">
+          <button type="button" className={tabClass("builtin")} onClick={() => setActiveTab("builtin")}>
+            Built-in
+          </button>
+          <button type="button" className={tabClass("page")} onClick={() => setActiveTab("page")}>
+            Page tools{pageTools.length > 0 ? ` (${pageTools.length})` : ""}
+          </button>
         </div>
+
+        {activeTab === "builtin" && (
+          <>
+            <p className="text-sm text-chrome-text-secondary">
+              Select which tools the agent can use. Changes will reset the current
+              conversation.
+            </p>
+
+            <div className="space-y-3 overflow-y-auto max-h-96">
+              {Object.values(AvailableTools).map((tool) => {
+                const metadata = toolMetadata[tool];
+                return (
+                  <div
+                    key={tool}
+                    className="flex items-start gap-3 rounded-lg border border-chrome-border p-3"
+                  >
+                    <input
+                      type="checkbox"
+                      id={tool}
+                      checked={selectedTools.has(tool)}
+                      onChange={() => handleToggle(tool)}
+                      className="mt-1 h-4 w-4 cursor-pointer rounded border transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none bg-chrome-bg-primary border-chrome-border text-chrome-accent-primary focus:border-chrome-accent-primary focus:ring-chrome-accent-primary focus:ring-offset-chrome-bg-primary"
+                    />
+                    <label htmlFor={tool} className="flex-1 cursor-pointer">
+                      <div className="text-sm font-medium text-chrome-text-primary">
+                        {metadata.label}
+                      </div>
+                      <div className="text-xs text-chrome-text-secondary mt-1">
+                        {metadata.description}
+                      </div>
+                    </label>
+                  </div>
+                );
+              })}
+            </div>
+          </>
+        )}
+
+        {activeTab === "page" && (
+          <>
+            <p className="text-sm text-chrome-text-secondary">
+              Tools the current page registered via WebMCP. These are always
+              available to the agent and are not affected by built-in tool
+              selection.
+            </p>
+
+            {pageTools.length === 0 ? (
+              <div className="rounded-lg border border-chrome-border p-4 text-sm text-chrome-text-secondary">
+                No WebMCP tools on this page.
+              </div>
+            ) : (
+              <ul className="space-y-2 overflow-y-auto max-h-96">
+                {pageTools.map((tool) => (
+                  <li
+                    key={tool.name}
+                    className="rounded-lg border border-chrome-border p-3"
+                  >
+                    <div className="text-sm font-medium text-chrome-text-primary">
+                      {tool.name}
+                    </div>
+                    {tool.description && (
+                      <div className="text-xs text-chrome-text-secondary mt-1">
+                        {tool.description}
+                      </div>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </>
+        )}
 
         <div className="flex justify-end gap-2 pt-4 border-t border-chrome-border">
           <Button
@@ -134,7 +198,7 @@ export default function ChatToolsModal({
             variant="solid"
             color="primary"
             onClick={handleSubmit}
-            disabled={isSubmitting}
+            disabled={isSubmitting || activeTab !== "builtin"}
             loading={isSubmitting}
           >
             Apply Changes

--- a/src/webmcp/content-bridge.ts
+++ b/src/webmcp/content-bridge.ts
@@ -1,0 +1,77 @@
+type CallResolver = (response: { ok: boolean; result?: unknown; error?: string }) => void;
+
+interface PendingCall {
+  resolve: CallResolver;
+  timeoutId: ReturnType<typeof setTimeout>;
+}
+
+const PENDING_CALL_TIMEOUT_MS = 30_000;
+const pendingCalls = new Map<string, PendingCall>();
+
+function makeId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+function settlePendingCall(
+  id: string,
+  response: { ok: boolean; result?: unknown; error?: string }
+) {
+  const pending = pendingCalls.get(id);
+  if (!pending) return;
+  pendingCalls.delete(id);
+  clearTimeout(pending.timeoutId);
+  pending.resolve(response);
+}
+
+function pushTools(tools: unknown) {
+  // Best-effort: the background service worker may be inactive during
+  // navigation or extension reload, in which case the call rejects with
+  // "Could not establish connection." We retry on the next push.
+  chrome.runtime.sendMessage({ type: "webmcp:tools", tools }).catch(() => {});
+}
+
+window.addEventListener("webmcp:list-response", (e: Event) => {
+  pushTools((e as CustomEvent).detail);
+});
+
+window.addEventListener("webmcp:tools-changed", (e: Event) => {
+  pushTools((e as CustomEvent).detail);
+});
+
+window.addEventListener("webmcp:call-response", (e: Event) => {
+  const { id, ok, result, error } = (e as CustomEvent).detail;
+  settlePendingCall(id, ok ? { ok, result } : { ok, error });
+});
+
+chrome.runtime.onMessage.addListener((msg, _sender, sendResponse) => {
+  if (msg?.type === "webmcp:request-list") {
+    window.dispatchEvent(new CustomEvent("webmcp:list-request"));
+    sendResponse({ ok: true });
+    return false;
+  }
+  if (msg?.type === "webmcp:call") {
+    const id = makeId();
+    // If the page never responds (navigates away, listener removed, hangs),
+    // free the entry and resolve the SW's sendMessage so the agent doesn't
+    // wait forever.
+    const timeoutId = setTimeout(() => {
+      settlePendingCall(id, {
+        ok: false,
+        error: `Timed out waiting for page tool '${msg.name}'`,
+      });
+    }, PENDING_CALL_TIMEOUT_MS);
+    pendingCalls.set(id, { resolve: sendResponse, timeoutId });
+    window.dispatchEvent(
+      new CustomEvent("webmcp:call-request", {
+        detail: { id, name: msg.name, args: msg.args },
+      })
+    );
+    return true;
+  }
+  return false;
+});
+
+window.dispatchEvent(new CustomEvent("webmcp:list-request"));

--- a/src/webmcp/page-bootstrap.ts
+++ b/src/webmcp/page-bootstrap.ts
@@ -1,0 +1,42 @@
+import { initializeWebMCPPolyfill } from "@mcp-b/webmcp-polyfill";
+
+initializeWebMCPPolyfill();
+
+const testing = (navigator as any).modelContextTesting as
+  | {
+      listTools?: () => Array<unknown>;
+      executeTool?: (name: string, argsJson: string) => Promise<unknown>;
+      registerToolsChangedCallback?: (cb: () => void) => void;
+    }
+  | undefined;
+
+function send(type: string, detail: unknown) {
+  window.dispatchEvent(new CustomEvent(type, { detail }));
+}
+
+window.addEventListener("webmcp:list-request", () => {
+  const tools = testing?.listTools?.() ?? [];
+  send("webmcp:list-response", tools);
+});
+
+window.addEventListener("webmcp:call-request", async (e: Event) => {
+  const { id, name, args } = (e as CustomEvent).detail;
+  try {
+    if (!testing?.executeTool) {
+      throw new Error("modelContextTesting.executeTool is not available");
+    }
+    const result = await testing.executeTool(name, JSON.stringify(args ?? {}));
+    send("webmcp:call-response", { id, ok: true, result });
+  } catch (err) {
+    send("webmcp:call-response", {
+      id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+});
+
+testing?.registerToolsChangedCallback?.(() => {
+  const tools = testing?.listTools?.() ?? [];
+  send("webmcp:tools-changed", tools);
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -89,20 +89,33 @@ export default defineConfig({
         sidebar: resolve(__dirname, "src/sidebar/index.html"),
         background: resolve(__dirname, "src/background/background.ts"),
         content: resolve(__dirname, "src/content/content.ts"),
+        "page-bootstrap": resolve(__dirname, "src/webmcp/page-bootstrap.ts"),
+        "content-bridge": resolve(__dirname, "src/webmcp/content-bridge.ts"),
       },
       output: {
         entryFileNames: (chunkInfo) => {
-          if (chunkInfo.name === "background" || chunkInfo.name === "content") {
+          if (
+            chunkInfo.name === "background" ||
+            chunkInfo.name === "content" ||
+            chunkInfo.name === "page-bootstrap" ||
+            chunkInfo.name === "content-bridge"
+          ) {
             return "[name].js";
           }
           return "assets/[name]-[hash].js";
         },
         chunkFileNames: "assets/[name]-[hash].js",
         assetFileNames: "assets/[name]-[hash].[ext]",
-        // Prevent code splitting for content script
+        // Prevent code splitting for content scripts (they must be self-contained)
         manualChunks: (id) => {
-          // If the module is imported by content script, inline it
-          if (id.includes('src/content') || id.includes('src/shared')) {
+          if (
+            id.includes("src/content") ||
+            id.includes("src/shared") ||
+            id.includes("src/webmcp") ||
+            id.includes("@mcp-b/webmcp-polyfill") ||
+            id.includes("@cfworker/json-schema") ||
+            id.includes("@standard-schema/spec")
+          ) {
             return undefined;
           }
         },


### PR DESCRIPTION
## What

Adds support for [WebMCP](https://github.com/MiguelsPizza/WebMCP) so the on-device Gemma agent can call tools that the current webpage registers via `navigator.modelContext`. When a site exposes its own catalog (e.g. `search_products`, `add_to_cart`, `checkout`), those tools appear in the side panel alongside the built-ins and the local model can invoke them. This is the same direction Chrome's native `navigator.modelContext` is moving toward.

## Demo

<!-- TODO: drop a 15–30s screen recording or GIF of a page tool being invoked. -->

## How it works

Three pieces:

1. **`src/webmcp/page-bootstrap.ts`** (MAIN world, `document_start`) — initializes the `@mcp-b/webmcp-polyfill` so `navigator.modelContext` is available to page scripts and bridges its events to `window` CustomEvents.
2. **`src/webmcp/content-bridge.ts`** (ISOLATED world, `document_start`) — forwards page events to the background service worker and routes inbound `webmcp:call` messages back into MAIN world. Pending calls have a 30 s timeout so an unresponsive page can't wedge the agent.
3. **`src/background/background.ts`** — keeps a `webmcpToolsByTab` registry, sanitizes incoming tool definitions (caps `description` length, validates `name` shape, strips control chars), and exposes proxy `WebMCPTool` objects whose `execute()` round-trips via `chrome.tabs.sendMessage("webmcp:call", …)`.

Agent-side changes (`src/background/agent/Agent.ts`):
- Page tools are listed before built-ins in the prompt — small models bias toward whichever tools they see first, and this materially improves selection on shopping/site pages.
- System prompt updated to (a) prefer page-specific tools when the request is about the current site and (b) treat product/feature names in the user message as data, not as instructions to refuse.
- If a tool call fails argument validation, the follow-up prompt asks the model to retry with corrected arguments instead of giving up.

UI (`src/sidebar/chat/ChatToolsModal.tsx`): a tabbed Configure Tools modal — Built-in (existing checkbox list) and Page tools (read-only list of what the current site has registered). The sidebar tracks the tabId associated with the page tools it's showing and sends it with each prompt, so the agent always uses the exact tool set the user can see.

## Test plan

- [ ] Side panel shows `Page tools (N)` in the Configure Tools modal on a site that registers WebMCP tools (e.g. https://store.nekuda.ai/).
- [ ] Asking the agent to use a page tool ("search hats", "add the cosmos one to cart", "find deals") actually invokes the registered tool.
- [ ] Switching tabs updates the page tool list within ~1 s of the new page registering its tools.
- [ ] On chrome://, extension, and file:// tabs the page tool list shows empty without errors in the SW console.

## Notes for reviewers

- **Independent fix:** the second commit hardens `askWebsite.ts` against `chrome.tabs.sendMessage` rejecting on non-http tabs. It was throwing uncaught `Could not establish connection` errors on every chrome:// or restricted-page activation independent of WebMCP. Happy to split it into its own PR if you'd prefer.
- **Prompt-injection surface:** page-controlled tool descriptions flow into the chat template. `sanitizeWebMCPTools` caps `description` at 512 chars, restricts `name` to `[A-Za-z0-9_-]{1,64}`, and strips control characters. JSON-Schema shape validation is delegated to the in-page polyfill (which already uses `@cfworker/json-schema`); happy to add a meta-validator on the background side if you'd like that defense-in-depth.
- **SW lifecycle:** `webmcpToolsByTab` is in-memory in the service worker. After SW unload, tools are repopulated when the page next emits `webmcp:tools-changed` or when the side panel re-asks via `WEBMCP_GET_TOOLS_FOR_ACTIVE_TAB`. Adding an SW-startup ping to all open tabs would close the gap; not done here to keep the diff focused.
- **Manifest breadth:** the two new content scripts run on `http(s)://*/*` at `document_start`. They're tiny (the bridge is ~80 lines and the polyfill bundle is ~30 KB) but they do load on every page. If you'd prefer lazy injection only when the side panel is open, that's a follow-up I'm happy to do.
- **Model behavior:** with ~20 total tools (7 built-in + a typical page catalog), Gemma 4 E2B occasionally picks the wrong tool or omits arguments. The page-tools-first ordering and the corrective-retry prompt mitigate this materially in testing but don't eliminate it. Switching to E4B helps further.

## Files

```
M  package.json + pnpm-lock.yaml      add @mcp-b/webmcp-polyfill
M  public/manifest.json               two new content scripts
M  vite.config.ts                     manualChunks: keep webmcp self-contained
A  src/webmcp/page-bootstrap.ts       MAIN-world polyfill init
A  src/webmcp/content-bridge.ts       ISOLATED-world event bridge
M  src/shared/types.ts                WebMCPToolSummary, new task/message ids
M  src/background/background.ts       registry, sanitizer, proxy tools
M  src/background/agent/Agent.ts      tool ordering, prompt, retry
M  src/background/agent/webMcp.tsx    bypassValidation flag
M  src/sidebar/chat/Chat.tsx          tabId tracking
M  src/sidebar/chat/ChatToolsModal.tsx  tabbed UI
M  src/background/tools/askWebsite.ts hardening (separate commit)
```