### PR TITLE
fix: resolve issue with sidebar scroll 

### DIFF
--- a/src/sidebar/chat/Chat.tsx
+++ b/src/sidebar/chat/Chat.tsx
@@ -178,26 +178,35 @@ export default function Chat() {
           ))
         )}
       </div>
+      <div className="sticky bottom-0 border-t border-chrome-border px-6 py-4 bg-chrome-bg-secondary z-20">
 
-      <div className="border-t border-chrome-border px-6 py-4 bg-chrome-bg-secondary relative">
-        <ChatCommands
-          ref={commandsRef}
-          commands={commands}
-          inputValue={inputValue}
-          isOpen={showCommands}
-          onClose={() => setShowCommands(false)}
-          onExecute={() => setShowCommands(false)}
-        />
-        {toolsOpen && (
-          <ChatToolsModal
-            activeTools={activeTools}
-            onClose={() => setToolsOpen(false)}
-            onSubmit={(tools: ToolName[]) => {
-              setActiveTools(tools);
-              setToolsOpen(false);
-            }}
+        {/* Commands dropdown */}
+        <div className="absolute bottom-full left-0 w-full mb-2 z-30">
+          <ChatCommands
+            ref={commandsRef}
+            commands={commands}
+            inputValue={inputValue}
+            isOpen={showCommands}
+            onClose={() => setShowCommands(false)}
+            onExecute={() => setShowCommands(false)}
           />
+        </div>
+
+        {/* Tools modal */}
+        {toolsOpen && (
+          <div className="absolute bottom-full left-0 w-full mb-2 z-30">
+            <ChatToolsModal
+              activeTools={activeTools}
+              onClose={() => setToolsOpen(false)}
+              onSubmit={(tools: ToolName[]) => {
+                setActiveTools(tools);
+                setToolsOpen(false);
+              }}
+            />
+          </div>
         )}
+
+        {/* Input Form */}
         <form onSubmit={handleSubmit(onSubmit)} className="flex gap-3">
           <Button
             type="button"
@@ -206,6 +215,7 @@ export default function Chat() {
             iconLeft={<Hammer />}
             onClick={() => setToolsOpen(true)}
           />
+
           <Controller
             name="input"
             control={control}
@@ -214,9 +224,7 @@ export default function Chat() {
               <InputText
                 {...field}
                 id="chat-input"
-                label="Message"
                 placeholder="Type your message or / for commands..."
-                //disabled={isLoading}
                 error={errors.input?.message}
                 hideLabel
                 className="flex-1"
@@ -228,6 +236,7 @@ export default function Chat() {
               />
             )}
           />
+
           <Button
             type="submit"
             disabled={isLoading || showCommands}

--- a/src/sidebar/chat/ChatToolsModal.tsx
+++ b/src/sidebar/chat/ChatToolsModal.tsx
@@ -85,32 +85,44 @@ export default function ChatToolsModal({
 
   return (
     <Modal title="Configure Tools" onClose={onClose}>
-      <div className="space-y-4">
-        <p className="text-sm text-chrome-text-secondary">
-          Select which tools the agent can use. Changes will reset the current
-          conversation.
-        </p>
+      <div className="flex flex-col h-full max-h-screen w-full mb-10">
+        {/* Header / Description */}
+        <div className="shrink-0 p-4 border-b border-chrome-border">
+          <p className="text-sm text-chrome-text-secondary">
+            Select which tools the agent can use. Changes will reset the current
+            conversation.
+          </p>
+        </div>
 
-        <div className="space-y-3 overflow-y-auto">
+        {/* Scrollable Tools Section */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-3 scrollbar-thin">
           {Object.values(AvailableTools).map((tool) => {
             const metadata = toolMetadata[tool];
+
             return (
               <div
                 key={tool}
-                className="flex items-start gap-3 rounded-lg border border-chrome-border p-3"
+                className="flex items-start gap-3 rounded-lg border border-chrome-border p-3 
+                     bg-chrome-bg-primary hover:bg-chrome-bg-secondary transition"
               >
                 <input
                   type="checkbox"
                   id={tool}
                   checked={selectedTools.has(tool)}
                   onChange={() => handleToggle(tool)}
-                  className="mt-1 h-4 w-4 cursor-pointer rounded border transition-colors focus:ring-2 focus:ring-offset-2 focus:outline-none bg-chrome-bg-primary border-chrome-border text-chrome-accent-primary focus:border-chrome-accent-primary focus:ring-chrome-accent-primary focus:ring-offset-chrome-bg-primary"
+                  className="mt-1 h-4 w-4 cursor-pointer rounded border 
+                       bg-chrome-bg-primary border-chrome-border
+                       text-chrome-accent-primary
+                       focus:ring-2 focus:ring-chrome-accent-primary
+                       focus:ring-offset-2 focus:ring-offset-chrome-bg-primary"
                 />
+
                 <label htmlFor={tool} className="flex-1 cursor-pointer">
                   <div className="text-sm font-medium text-chrome-text-primary">
                     {metadata.label}
                   </div>
-                  <div className="text-xs text-chrome-text-secondary mt-1">
+
+                  <div className="mt-1 text-xs text-chrome-text-secondary">
                     {metadata.description}
                   </div>
                 </label>
@@ -119,26 +131,32 @@ export default function ChatToolsModal({
           })}
         </div>
 
-        <div className="flex justify-end gap-2 pt-4 border-t border-chrome-border">
-          <Button
-            type="button"
-            variant="ghost"
-            color="secondary"
-            onClick={onClose}
-            disabled={isSubmitting}
-          >
-            Cancel
-          </Button>
-          <Button
-            type="button"
-            variant="solid"
-            color="primary"
-            onClick={handleSubmit}
-            disabled={isSubmitting}
-            loading={isSubmitting}
-          >
-            Apply Changes
-          </Button>
+        {/* Footer Buttons */}
+        <div className="shrink-0 border-t border-chrome-border p-4 bg-chrome-bg-primary">
+          <div className="flex flex-col sm:flex-row justify-end gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              color="secondary"
+              onClick={onClose}
+              disabled={isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Cancel
+            </Button>
+
+            <Button
+              type="button"
+              variant="solid"
+              color="primary"
+              onClick={handleSubmit}
+              disabled={isSubmitting}
+              loading={isSubmitting}
+              className="w-full sm:w-auto"
+            >
+              Apply Changes
+            </Button>
+          </div>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Fixes

Fixes #12

## Problem

The tool selection modal could overflow on smaller laptop screens, preventing users from scrolling through all available tools and accessing footer actions. This was reported on Microsoft Edge, and the issue appeared to be related to modal height/overflow behavior.

## Changes Made

* Updated `ChatToolsModal.tsx` to use a proper flex-based layout
* Added `overflow-y-auto` for the tools list section
* Kept header and footer fixed while allowing only the middle section to scroll
* Updated `Chat.tsx` so the tools modal and command dropdown open correctly above the chat input
* Improved responsiveness for smaller viewport sizes

## Testing

Tested locally on:

* Google Chrome
* Smaller laptop viewport

Verified:

* Tool modal scroll works properly
* Footer buttons remain accessible
* Modal closes correctly
* Chat input remains fixed at the bottom

## Demo Video

https://github.com/user-attachments/assets/f013e884-9f84-4922-8424-58a08b405233
